### PR TITLE
implement as browserify transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
 # cypress-cucumber-preprocessor
 A preprocessor for running Gherkin 3 features as Cypress tests
+
+## Installation
+
+Install this plugin:
+
+```shell
+npm install --save-dev cypress-cucumber-preprocessor
+```
+
+## Step definitions
+
+Put your step definitions in cypress/support/step_definitions
+
+Examples:
+cypress/support/step_definitions/google.js
+```javascript
+const {given} = require('cypress-cucumber-preprocessor')
+
+// you can have external state, and also require things!
+const url = 'https://google.com'
+
+given('I open Google page', () => {
+  cy.visit(url)
+})
+```
+
+cypress/support/step_definitions/shared.js
+```javascript
+const {then} = require('cypress-cucumber-preprocessor')
+
+then(`I see {string} in the title`, (title) => {
+  cy.title().should('include', title)
+})
+```
+
+The requires are optional - you can just use 
+```javascript
+/* global then, when, given */
+```
+to make IDE happy
+
+## Spec/Feature files
+Your feature file in cypress/integration:
+
+Example: cypress/integration/Facebook.feature
+```gherkin
+Feature: The Facebook
+
+  I want to open a social network page
+
+  Scenario: Opening a social network page
+    Given I open Facebook page
+    Then I see "Facebook" in the title
+```
+
+## Configuration
+Add it to your plugins:
+
+cypress/plugins/index.js
+```javascript
+const cucumber = require('cypress-cucumber-preprocessor')
+module.exports = (on, config) => {
+  on('file:preprocessor', cucumber())
+}
+```
+
+## Running
+
+Run your cypress the way you would normally do :) click on a .feature file on the list of specs, and see the magic happening!
+
+## Disclaimer
+
+This is a very fresh code, please let me know if you find any issues or have suggestions for improvements.
+
+## TODO
+
+Scenario
+
+## Credit where it's due!
+
+Based/inspired on great work on https://github.com/sitegeist/gherkin-testcafe , although, with this package we don't have to run cypress programatically - with an external runner, we can use cypress as we are used to :) 
+
+Thanks to the Cypress team for the fantastic work and very exciting tool! :-)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const EventEmitter = require('events').EventEmitter;
+const through = require('through');
+
+const browserify = require('@cypress/browserify-preprocessor');
+
+const log = require('debug')('cypress:cucumber');
+const glob = require('glob');
+
+const watchers = {};
+
+// This is the template for the file that we will send back to cypress instead of the text of a
+// feature file
+const createCucumber = (spec, definitions) => (
+  `
+  const {resolveAndRunStepDefinition, given, when, then} = require('cypress-cucumber-preprocessor/resolveStepDefinition');
+  ${eval(definitions).join('\n')}
+  const {Parser, Compiler} = require('gherkin');
+  const spec = \`${spec}\`
+  const gherkinAst = new Parser().parse(spec);
+  describe(gherkinAst.feature.name, () => {
+    gherkinAst.feature.children.forEach(createTestFromScenario);
+  });
+  function createTestFromScenario (scenario) {
+    describe(scenario.name, () => {
+        scenario.steps.map(
+          step => it(step.text, () => {
+            resolveAndRunStepDefinition(step)
+          })
+        )
+      }
+    )
+  }`
+);
+
+const pattern = `${process.cwd()}/cypress/support/step_definitions/**.js`;
+const stepDefinitionsPaths = [].concat(glob.sync(pattern));
+
+const compile = (spec) => {
+  log('compiling', spec);
+
+  const definitions = [];
+  stepDefinitionsPaths.forEach((path) => {
+    definitions.push(
+      `{ ${fs.readFileSync(path).toString().replace('cypress-cucumber-preprocessor', 'cypress-cucumber-preprocessor/resolveStepDefinition')}
+      }`
+    );
+  });
+
+  return createCucumber(spec, JSON.stringify(definitions));
+};
+
+
+const touch = (filename) => {
+  fs.utimesSync(filename, new Date(), new Date());
+};
+
+
+const transform = (file) => {
+  let data = '';
+
+  function write(buf) { data += buf; }
+  function end() {
+    if (file.match('.feature$')) {
+      log('compiling feature ', file);
+      this.queue(compile(data));
+    } else {
+      this.queue(data);
+    }
+    this.queue(null);
+  }
+
+  return through(write, end);
+};
+
+
+const preprocessor = (options) => {
+  return file => {
+
+    options.browserifyOptions.transform.unshift(
+      transform
+    );
+
+    if (file.shouldWatch) {
+
+      stepDefinitionsPaths.forEach((stepPath) => {
+        if (watchers[stepPath] === undefined) {
+          const stepFile = new EventEmitter();
+          stepFile.filePath = stepPath;
+
+          const bundleDir = file.outputPath.split('/').slice(0, -2);
+          const outputName = stepPath.split('/').slice(-3);
+          stepFile.outputPath = bundleDir.concat(outputName).join('/');
+          stepFile.shouldWatch = file.shouldWatch;
+
+          stepFile.on('rerun', () => {
+            touch(file.filePath);
+          });
+          watchers[stepPath] = browserify(options)(stepFile);
+        } else {
+          log(`Watcher already set for ${stepPath}`);
+        }
+      })
+
+    }
+    return browserify(options)(file);
+  };
+};
+
+module.exports = {
+  default: preprocessor,
+  transform: transform,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cypress-cucumber-preprocessor",
+  "version": "0.0.2",
+  "description": "Run gherkin-syntaxed specs with cypress.io",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NoNameProvided/cypress-cucumber-preprocessor.git"
+  },
+  "keywords": [
+    "cucumber",
+    "gherkin",
+    "cypress",
+    "testing"
+  ],
+  "author": "Lukasz Gandecki",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/NoNameProvided/cypress-cucumber-preprocessor/issues"
+  },
+  "homepage": "https://github.com/NoNameProvided/cypress-cucumber-preprocessor#readme"
+}

--- a/resolveStepDefinition.js
+++ b/resolveStepDefinition.js
@@ -1,0 +1,70 @@
+const path = require('path');
+
+const {CucumberExpression, ParameterTypeRegistry} = require('cucumber-expressions');
+
+const parameterTypeRegistry = new ParameterTypeRegistry();
+
+class StepDefinitionRegistry {
+  constructor() {
+    this.definitions = {};
+    this.runtime = {};
+    this.latestType = '';
+
+    ['given', 'when', 'then'].forEach(keyword => {
+      this.definitions[keyword] = [];
+      this.runtime[keyword] = (expression, implementation) => {
+        this.definitions[keyword].push({
+
+          implementation,
+          expression: new CucumberExpression(expression, parameterTypeRegistry)
+        })
+      };
+    })
+
+    this.load = definitionFactoryFunction => definitionFactoryFunction(this.runtime);
+
+    this.resolve = (type, text) => {
+      if (type === 'and') {
+        type = this.latestType;
+      }
+
+      if (this.definitions[type]) {
+        this.latestType = type;
+        return this.definitions[type].filter(({expression}) => expression.match(text))[0]
+      }
+    }
+  }
+
+}
+
+const stepDefinitionRegistry = new StepDefinitionRegistry();
+
+function resolveStepDefinition(step) {
+  const stepDefinition = stepDefinitionRegistry.resolve(step.keyword.toLowerCase().trim(), step.text);
+
+  return stepDefinition || {};
+}
+
+module.exports = {
+  resolveAndRunStepDefinition: (step) => {
+
+    const {expression, implementation} = resolveStepDefinition(step)
+    if (expression && implementation) {
+      return implementation(
+        ...expression.match(step.text).map(match => match.getValue())
+      )
+    } else {
+      throw new Error(`Step implementation missing for: ${step.text}`)
+    }
+  },
+  given: (expression, implementation) => {
+    stepDefinitionRegistry.runtime.given(expression, implementation)
+  },
+  when: (expression, implementation) => {
+    stepDefinitionRegistry.runtime.when(expression, implementation)
+
+  },
+  then: (expression, implementation) => {
+    stepDefinitionRegistry.runtime.then(expression, implementation)
+  }
+}


### PR DESCRIPTION
I took the original code and implemented it as browserify transform. This way we don't need to write temporary files to disk and we can leverage `@cypress/browserify-preprocessor`'s handling of watchers and reloading.

I've also made the preprocessor accept options to be passed down to browserify.

Note: I've used the airbnb style simply because that's what I usually have set up. If you prefer a different style, let me know and I'll make the changes (maybe add an `.eslintrc` to the repo?)